### PR TITLE
Fix deploy workflow adding generic credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,5 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config user.name "$GITHUB_ACTOR"
           git remote set-url origin "https://fregante:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
           npm run deploy:catalogue


### PR DESCRIPTION
Fixes the errors we've been getting on deploy by providing the workflow with generic git credentials for accessing github pages.

Tested on [staging branch](https://github.com/nearform/libp2p-introspection-ui/tree/staging) viewable on the build https://nearform.github.io/libp2p-introspection-ui/