### PR TITLE
Generating mock files from stdout works fine

### DIFF
--- a/packages/samples/mock/mock.js
+++ b/packages/samples/mock/mock.js
@@ -50,7 +50,6 @@ if (filePath) {
 
 const bufferSegments = generate(connectionsCount, durationSeconds)
 
-// TODO: write to file works, but process.stdout > file writes broken binary
 const writer = filePath ? createWriteStream(filePath) : process.stdout
 
 writer.write(bufferSegments)


### PR DESCRIPTION
This functionality actually works. Removing comment in code.

Running `node ./mock/mock.js > somefile` generates valid output.

The problem is with running the npm-script. This echos the execution command in front of the data, which ends up in the file.

Alternative way to run the npm-script:
`npm run mock --silent > somefile`
 