### PR TITLE
Avoid actual 0 in mock data randomisation

### DIFF
--- a/packages/samples/mock/utils.js
+++ b/packages/samples/mock/utils.js
@@ -35,8 +35,10 @@ function getRandomiser() {
 
   const isTest = !!process.env.TAP
 
+  // The *tiny* but real chance of Math.random() returning actual 0 is an edge case we don't need
+  const randomAndTruthy = () => Math.random() || randomAndTruthy()
   /* istanbul ignore if */
-  if (!isTest) return Math.random
+  if (!isTest) return randomAndTruthy
 
   let index = 0
   const pseudoRandom = () => {


### PR DESCRIPTION
While demonstrating web sockets data this morning, I got an unexpected `Assertion failed` error in the mock data script, from `DataGauge`.

Digging deeper it looks like this was caused by the <1 in a million chance of Math.random() returning actual `0` for the `u` value in the random normal distribution function.

We could carefully check that every function, now and in future, can handle an exact `0`... but it's much less burden to simply stop `random()` from returning exact `0`.

(also, what is it about Zoom's screen share feature that causes every rare, intermittent bug or edge case to happen?!)