### PR TITLE
[WIP] Update protobuf def for event types and DHT status changes

### DIFF
--- a/packages/proto/lib/introspection.proto
+++ b/packages/proto/lib/introspection.proto
@@ -256,23 +256,19 @@ message DHT {
         CANDIDATE = 3;
     }
 
-    message Change {
+    message StatusChange {
+      // time change occurred
       google.protobuf.Timestamp change_ts = 1;
-
-      oneof message {
-        Status prior_status  = 2;
-        bool prior_in_bucket = 3;
-      }
+      // current status of the peer at timestamp
+      Status status  = 2;
+      // peer is in bucket=kad-distance (else, catch-all bucket 0)
+      bool in_bucket = 3;
     }
 
     // the peer id of the host system
     string peer_id          = 1;
-    // peer is in bucket=kad-distance (else, catch-all bucket 0)
-    bool in_bucket          = 2;
-    // current status of the peer
-    Status status           = 3;
     // changes occuring in this time interval
-    repeated Change changes = 4;
+    repeated StatusChange changes = 2;
   }
 
   message Query {


### PR DESCRIPTION
I need to think about this some more and sanity-check the UI-side implementation, then will request reviews so we'll be ready to discuss it with PL on Monday.

Basic thinking:

### Events metadata

Trying to keep this to the minimum that allows us to better display events. Fallback would be to display everything as strings if this runtime data is missing or an event doesn't fit the provided schema.

If the person configuring the introspection is able to define event types like this, I don't think we need the event subscribe / unsubscribe signalling we discussed.

### DHT changes

"Age in bucket" was pretty confusing before and doesn't fit so well with the livelier picture we now have of peers potentially moving back and forth between a full bucket and the "replacement candidate" list. Bucket number is essentially a boolean as it's always either `0` or the peer ID's kadamelia distance. So, I think it makes more sense for a state message to contain the current status and a list of timestamped changes to the peer's status that occurred during the state message's time interval. Then the UI would interpolate those changes the same way it does queries. 

This makes the handling of peers more consistent with the handling of queries and ensures the timing of the UI displaying queries is consistent with the timing of the UI displaying peer state changes or movements to a bucket.