### PR TITLE
Sort timeline X-axis to handle out-of-sequence states

### DIFF
--- a/packages/shell/components/Timeline/Timeline.js
+++ b/packages/shell/components/Timeline/Timeline.js
@@ -3,7 +3,7 @@ import T from 'prop-types'
 import styled from 'styled-components'
 import { withResizeDetector } from 'react-resize-detector'
 
-import { useStackedData, getNumericSorter } from '@libp2p-observer/sdk'
+import { useStackedData } from '@libp2p-observer/sdk'
 
 import { getTrafficChangesByPeer, getTotalTraffic, getPeerIds } from './utils'
 import TimelinePaths from './TimelinePaths'
@@ -42,15 +42,13 @@ function Timeline({ width = 700, leftGutter }) {
   const { stackedData, xScale, yScale: yScaleIn } = useStackedData({
     keyData: getTrafficChangesByPeer('in'),
     getKeys: getPeerIds,
-    getSorter: getNumericSorter,
-    mapSorter: getTotalTraffic,
+    mapYSorter: getTotalTraffic,
   })
 
   const { stackedData: stackedDataOut, yScale: yScaleOut } = useStackedData({
     keyData: getTrafficChangesByPeer('out'),
     getKeys: getPeerIds,
-    getSorter: getNumericSorter,
-    mapSorter: getTotalTraffic,
+    mapYSorter: getTotalTraffic,
   })
 
   // Make sure both data in and out use the same scale


### PR DESCRIPTION
I found a few more even rarer instances of the "messed up timeline with websockets data" bug after the latest fixes, and figured out that they were caused by states being sent out of sequence.  

Rather than fixing whatever in the mock data server is causing states to be sent out of sequence, based on the principle of "correctly render whatever data is thrown at us" I've added x-axis sorting to the timeline and related hooks so that out-of-sequence data is still rendered correctly. Since we don't have control over the introspection server it's good to have resilience. I've checked the performance and this extra sort adds less than 1ms to the time taken to handle incoming states even when out of sequence.