### PR TITLE
Stop z-index failing because element has transform

### DIFF
--- a/packages/sdk/components/DataTable/DataTableRow.js
+++ b/packages/sdk/components/DataTable/DataTableRow.js
@@ -50,7 +50,7 @@ function DataTableRow({
       setTimeout(() => {
         if (!rowRef.current) return
         rowRef.current.style.transition = '500ms transform ease-in'
-        rowRef.current.style.transform = 'translateY(0px)'
+        rowRef.current.style.transform = ''
       })
     }
   }, [rowRef, yFrom])


### PR DESCRIPTION
This fixes a bug that resulted as a side effect of improving the sliding rows animations by applying transforms directly to the table rows: having a `transform` CSS style applied makes an element behave as if it has a z-index stacking context (even if it's something like a table row that can't have a z-index), which caused the rows below to overlap popups, but only if they had already animated:

![image](https://user-images.githubusercontent.com/29628323/81649868-e46a5d00-9428-11ea-9345-0ce46d6166b3.png)

This fixes that by removing the transform instead of setting it to 0.