### PR TITLE
refactor command RPCs.

### DIFF
--- a/packages/proto/lib/introspection.proto
+++ b/packages/proto/lib/introspection.proto
@@ -375,10 +375,10 @@ message ClientCommand {
         REQUEST         = 1;
 
         // PUSH streams can only be started for STATE and EVENTS sources.
-        START_PUSH      = 2;
-        STOP_PUSH       = 3;
-        PAUSE_PUSH      = 4;
-        RESUME_PUSH     = 5;
+        PUSH_ENABLE     = 2; // enables pushing for a given source.
+        PUSH_DISABLE    = 3; // disables pushing for a given source.
+        PUSH_PAUSE      = 4; // pauses pushing for all sources.
+        PUSH_RESUME     = 5; // resumes pushing for all sources.
 
         // UPDATE_CONFIG requests a configuration update. The config field is
         // compulsory.


### PR DESCRIPTION
This pull request proposes a few minor protocol changes at the RPC level.

* Renames and new messages.
  * `ClientSignal` is renamed to `ClientCommand`.
  * We introduce a `CommandResponse` message for protocol completeness.
  * We introduce a `ServerNotice` message so that the server can signal circumstances to the client, e.g. that retained messages are being dropped.
* The configuration is now expressed in Protobuf, and not in embedded JSON any longer.
* The `CONFIG_EMITTER` command is replaced by an `UPDATE_CONFIG` command.
  * The client sends the requested configuration in the `config` field.
  * The server will respond with a `CommandResponse` including the effective configuration.
* We introduce a `HELLO` command that the client must greet the server with upon establishing a WS connection. It can optionally send a `config` object.
* We introduce a `CommandResponse` object with which the server returns the result of a command.
* We introduce unique command IDs so we can correlate requests and responses (we don't expect parallelism right now).
* For completeness, we introduce a `STOP_PUSH` command.